### PR TITLE
Added support for `add_respondents_data_without_email_invitation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple Ruby client for QuestBack's SOAP API.
 
-[ ![Codeship Status for matsve/quest_back](https://codeship.com/projects/74070280-df99-0133-54e5-460ef9277ccd/status?branch=master)](https://codeship.com/projects/145033)
+[![Build Status](https://travis-ci.org/Skalar/quest_back.svg?branch=master)](https://travis-ci.org/Skalar/quest_back)
 
 ### WARNING
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple Ruby client for QuestBack's SOAP API.
 
-[![Build Status](https://travis-ci.org/Skalar/quest_back.svg?branch=master)](https://travis-ci.org/Skalar/quest_back)
+![Codeship build status](https://codeship.com/projects/74070280-df99-0133-54e5-460ef9277ccd/status?branch=master)
 
 ### WARNING
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple Ruby client for QuestBack's SOAP API.
 
-![Codeship build status](https://codeship.com/projects/74070280-df99-0133-54e5-460ef9277ccd/status?branch=master)
+[ ![Codeship Status for matsve/quest_back](https://codeship.com/projects/74070280-df99-0133-54e5-460ef9277ccd/status?branch=master)](https://codeship.com/projects/145033)
 
 ### WARNING
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple Ruby client for QuestBack's SOAP API.
 
-[![Build Status](https://travis-ci.org/Skalar/quest_back.svg?branch=master)](https://travis-ci.org/Skalar/quest_back)
+[ ![Codeship Status for matsve/quest_back](https://codeship.com/projects/74070280-df99-0133-54e5-460ef9277ccd/status?branch=master)](https://codeship.com/projects/145033)
 
 ### WARNING
 

--- a/lib/quest_back/api.rb
+++ b/lib/quest_back/api.rb
@@ -20,6 +20,7 @@ module QuestBack
       get_quests: [:user_info, :paging_info, :quest_filter],
       add_email_invitees: [:user_info, :quest_info, :emails, :sendduplicate, :language_id],
       add_respondents_data: [:user_info, :quest_info, :respondents_data, :language_id],
+      add_respondents_data_without_email_invitation: [:user_info, :quest_info, :respondents_data, :language_id],
       add_respondents_data_with_sms_invitation: [
         :user_info, :quest_info, :respondents_data, :language_id,
         :sms_from_number, :sms_from_text, :sms_message
@@ -39,6 +40,7 @@ module QuestBack
       get_language_list: [:language],
       add_email_invitees: [],
       add_respondents_data: [],
+      add_respondents_data_without_email_invitation: [],
       add_respondents_data_with_sms_invitation: []
     }
 
@@ -170,6 +172,56 @@ module QuestBack
     # Returns QuestBack::Response
     def add_respondents_data(attributes = {})
       call :add_respondents_data, attributes, include_defaults: [:respondents_data]
+    end
+
+    # Public: Add respondent data to a quest - optionally send as invitee as well.
+    #         This will not send an email invitation through Questback's platform
+    #
+    # attributes    -   Attributes sent to QuestBack
+    #
+    # QuestBack is doing a bit of CSV over XML here? As you need to serialize
+    # respondent_data as a string with a delimiter ala CSV. The order of the
+    # data must match the order of respondent_data_header. I guess simply using XML
+    # and named elements was too easy? :-)
+    #
+    # Example
+    #
+    #   response = api.add_respondents_data_without_email_invitation(
+    #     quest_info: {quest_id: 4567668, security_lock: 'm0pI8orKJp'},
+    #     respondents_data: {
+    #       respondent_data_header: {
+    #         respondent_data_header: [
+    #           {
+    #             title: 'Epost',
+    #             type: QuestBack::Api.respondent_data_header_type_for(:text),
+    #             is_email_field: true,
+    #             is_sms_field: false,
+    #           },
+    #           {
+    #             title: 'Navn',
+    #             type: QuestBack::Api.respondent_data_header_type_for(:text),
+    #             is_email_field: false,
+    #             is_sms_field: false,
+    #           },
+    #           {
+    #             title: 'Alder',
+    #             type: QuestBack::Api.respondent_data_header_type_for(:numeric),
+    #             is_email_field: false,
+    #             is_sms_field: false,
+    #           },
+    #         ]
+    #       },
+    #       respondent_data: ['th@skalar.no;Thorbjorn;32'], # According to QuestBack's doc you can only do one here
+    #       allow_duplicate: true,
+    #       add_as_invitee: true
+    #     }
+    #   )
+    #
+    # You may override respondent_data's delimiter in string too.
+    #
+    # Returns QuestBack::Response
+    def add_respondents_data_without_email_invitation(attributes = {})
+      call :add_respondents_data_without_email_invitation, attributes, include_defaults: [:respondents_data]
     end
 
     # Public: Add respondent data to a quest with SMS invitation


### PR DESCRIPTION
We needed this function, and thought that it would be nice to contribute back to your helpful gem. Thanks :)